### PR TITLE
Implemented all lib-version requirements 

### DIFF
--- a/.github/maven/settings.xml
+++ b/.github/maven/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>github</id>
+            <username></username>
+            <password></password>
+        </server>
+    </servers>
+</settings>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'  # e.g., v1.0.0
+  workflow_dispatch:
 
 jobs:
   release:
@@ -12,6 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: version-util
+          ref: main
           fetch-depth: 0
 
       - name: Set up JDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: version-util
           fetch-depth: 0
 
       - name: Set up JDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
           sed -i "s|<password>.*</password>|<password>${{ secrets.GH_PAT }}</password>|" ~/.m2/settings.xml
 
       - name: Deploy to GitHub Packages
-        run: mvn deploy -DskipTests -DdryRun=true
+        run: mvn deploy -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release to GitHub Packages
+
+on:
+  push:
+    tags:
+      - 'v*'  # e.g., v1.0.0
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '16'
+          distribution: 'temurin'
+
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set version in pom.xml
+        run: mvn versions:set -DnewVersion=${VERSION#v} -DgenerateBackupPoms=false
+
+      - name: Commit updated pom.xml
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "Update version to ${VERSION#v}"
+          git push
+
+      - name: Copy Maven settings.xml
+        run: |
+          mkdir -p ~/.m2
+          cp .github/maven/settings.xml ~/.m2/settings.xml
+
+      - name: Inject GitHub credentials
+        run: |
+          sed -i "s|<username>.*</username>|<username>sten-vw</username>|" ~/.m2/settings.xml
+          sed -i "s|<password>.*</password>|<password>${{ secrets.GH_PAT }}</password>|" ~/.m2/settings.xml
+
+      - name: Deploy to GitHub Packages
+        run: mvn deploy -DskipTests -DdryRun=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # lib-version
+This is a Java Maven package that reports the current version of this package.
+The repository has a github actions workflow which builds and uploads the package to the Github Packages repository. This action is triggered when a version tag (starting with "v" e.g. "v1.0.0") is pushed to the repo. It will also automatically change the version in `pom.xml`.
+
+The upload to the package registry currently uses `sten-vw` as a hardcoded username, as I needed to configure a custom PAT for this.

--- a/pom.xml
+++ b/pom.xml
@@ -15,4 +15,13 @@
         <maven.compiler.target>16</maven.compiler.target>
     </properties>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.remla25team6</groupId>
     <artifactId>lib-version</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0TEST</version>
 
     <name>lib-version</name>
     <description>A version-aware library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -24,4 +24,12 @@
         </resources>
     </build>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/remla25-team6/lib-version</url>
+        </repository>
+    </distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.remla25team6</groupId>
+    <artifactId>lib-version</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>lib-version</name>
+    <description>A version-aware library</description>
+    <properties>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
+    </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.remla25team6</groupId>
     <artifactId>lib-version</artifactId>
-    <version>1.0.0TEST</version>
+    <version>1.0.SNAPSHOT</version>
 
     <name>lib-version</name>
     <description>A version-aware library</description>

--- a/src/main/java/org/remla25team6/libversion/VersionUtil.java
+++ b/src/main/java/org/remla25team6/libversion/VersionUtil.java
@@ -1,4 +1,45 @@
 package org.remla25team6.libversion;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class VersionUtil {
+
+    private static final String PROPERTIES = "version.properties";
+    private static String libraryVersion = null;
+
+    /**
+     * Gets the version of this library.
+     * Only attempts to read file if it was not successfully retrieved before.
+     *
+     * @return The library version string or null if not found.
+     */
+    public static String getVersion() {
+        if (libraryVersion == null) {
+            libraryVersion = findVersion();
+        }
+        return libraryVersion;
+    }
+
+    /**
+     * Retrieves the version of the library from the version.properties file, which is populated by maven filtering.
+     *
+     * @return The library version string or null if not found.
+     */
+    public static String findVersion() {
+        Properties props = new Properties();
+        try (InputStream input = VersionUtil.class.getClassLoader().getResourceAsStream("version.properties")) {
+            if (input == null) {
+                return null;
+            }
+
+            props.load(input);
+            String version = props.getProperty("library.version");
+            return version;
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/remla25team6/libversion/VersionUtil.java
+++ b/src/main/java/org/remla25team6/libversion/VersionUtil.java
@@ -29,7 +29,7 @@ public class VersionUtil {
      */
     public static String findVersion() {
         Properties props = new Properties();
-        try (InputStream input = VersionUtil.class.getClassLoader().getResourceAsStream("version.properties")) {
+        try (InputStream input = VersionUtil.class.getClassLoader().getResourceAsStream(PROPERTIES)) {
             if (input == null) {
                 return null;
             }

--- a/src/main/java/org/remla25team6/libversion/VersionUtil.java
+++ b/src/main/java/org/remla25team6/libversion/VersionUtil.java
@@ -1,0 +1,4 @@
+package org.remla25team6.libversion;
+
+public class VersionUtil {
+}

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+library.version=${project.version}


### PR DESCRIPTION
- `VersionUtil.class` reads the `version.properties` file to retrieve the version of this library. The properties file is dynamically populated by maven with the correct version from `pom.xml`.
- There is a Github Actions workflow that is triggered when a version tag in the form "v*" is pushed. This will update the version in the `pom.xml` file and then push the package to the Github Packages registry. 